### PR TITLE
Fix 404 page stylesheet path

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,1 +1,21 @@
-<!DOCTYPE html><title>404</title><meta name=author content="Rishabh Tulsian"><link rel=stylesheet href=stylesheets/style.css><div class=not-found><div class=message><h1>404!</h1><p>Sorry, the page you are looking for was<br>not found.<br><em>This is certainly not the page I was looking<br>for either :)</em></div></div>
+---
+layout: none
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>404</title>
+    <meta name="author" content="Rishabh Tulsian">
+    <link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/style.css">
+  </head>
+  <body>
+    <div class="not-found">
+      <div class="message">
+        <h1>404!</h1>
+        <p>Sorry, the page you are looking for was<br>not found.<br><em>This is certainly not the page I was looking<br>for either :)</em></p>
+      </div>
+    </div>
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- ensure 404 page references stylesheet using `site.baseurl`
- add front matter so Jekyll processes 404 page without layout

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a00c32170083219adc9add06039e78