### PR TITLE
Clarify permalink configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,10 @@
-# Permalinks
-permalink:           pretty
-
 # Setup
 title:               Rishabh Tulsian
 tagline:             Whimsical Coder
 url:                 https://rishabh.tulsian.com
 baseurl:             ""
-permalink:           "/blog/:year/:month/:day/:title.html"
+# Permalink structure for blog posts
+permalink: "/blog/:year/:month/:day/:title.html"
 
 # Assets
 # We specify the directory for Jekyll so we can use @imports.


### PR DESCRIPTION
## Summary
- Keep blog post permalink after `baseurl` and remove redundant configuration
- Document permalink structure for clarity

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a00e88d3648321a1965bd03a7ca467